### PR TITLE
Move `ssh_keys_known_hosts_path` from vars to defaults for easier override

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@ ssh_keys_private_keys: []
 ssh_keys_public_keys: []
 ssh_keys_authorized_keys: []
 ssh_keys_known_hosts: []
+ssh_keys_known_hosts_path: "~/.ssh/known_hosts_ansible"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,6 @@
 ssh_keys_sshdir: '.ssh'
 ssh_keys_private_key_filename: 'id_rsa'
 ssh_keys_public_key_filename: 'id_rsa.pub'
-ssh_keys_known_hosts_path: /etc/ssh/ssh_known_hosts
 _ssh_keys_generate_keys_command: >-
   openssl \
     gen{{ item.type | default('rsa') }} \


### PR DESCRIPTION
Move `ssh_keys_known_hosts_path` from `vars/main.yml` to `defaults/main.yml` so it is easier to override